### PR TITLE
ci: fix gitlab-ci configuration typo and code style issue

### DIFF
--- a/template/.gitlab-ci.yml
+++ b/template/.gitlab-ci.yml
@@ -245,5 +245,5 @@ jest:
     - if: $CI_COMMIT_BRANCH =~ /^release.*$/
     - if: $CI_COMMIT_BRANCH =~ /^hotfix.*$/
   dependencies:
-    - 🛠build:android:drdevgon
+    - 🛠build:android:dev
   when: manual

--- a/template/metro.config.js
+++ b/template/metro.config.js
@@ -1,4 +1,4 @@
-const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 /**
  * Metro configuration
  * https://reactnative.dev/docs/metro


### PR DESCRIPTION
Fix the issue while running the pipeline : 

> 🚀deploy-client:android:production job: undefined dependency: 🛠build:android:drdevgon
